### PR TITLE
Update fonts for document components

### DIFF
--- a/components/contrato-servicios.tsx
+++ b/components/contrato-servicios.tsx
@@ -64,9 +64,9 @@ export function ContratoServicios({
     <div
       className="contract-document"
       style={{
-        fontFamily: "Arial, sans-serif",
+        fontFamily: "Times New Roman, serif",
         fontSize: "11pt",
-        lineHeight: 1.6,
+        lineHeight: 1.3,
         letterSpacing: "0.2px",
         width: "100%",
         maxWidth: "210mm",

--- a/components/document-modal.tsx
+++ b/components/document-modal.tsx
@@ -414,9 +414,11 @@ export function DocumentModal({
   }
 
   const PDF_CSS = `
-  .pdf-optimized { font-family: 'Segoe UI', sans-serif; line-height:1.4; }
-  .pdf-optimized table { border-collapse:collapse; width:100%; font-size:10pt; }
+  .pdf-optimized { font-family: 'Times New Roman', serif; line-height:1.3; }
+  .pdf-optimized table { border-collapse:collapse; width:100%; font-size:11pt; }
   .pdf-optimized th, .pdf-optimized td { border:1px solid #bdc3c7; padding:6pt; }
+  .pdf-optimized h1 { font-family: 'Segoe UI', sans-serif; font-size:11pt; }
+  .pdf-optimized h2 { font-family: 'Segoe UI', sans-serif; font-size:10pt; }
   /* overrides Tailwind */
   .pdf-optimized .text-4xl { font-size:22pt !important; }
 `;

--- a/components/documents/audit-agreement-document.tsx
+++ b/components/documents/audit-agreement-document.tsx
@@ -44,9 +44,9 @@ export function AuditAgreementDocument({
     <div
       className="audit-agreement-document"
       style={{
-        fontFamily: "Times New Roman, Times, serif",
-        fontSize: "12pt",
-        lineHeight: 1.5,
+        fontFamily: "Times New Roman, serif",
+        fontSize: "11pt",
+        lineHeight: 1.3,
         width: "100%",
         maxWidth: "210mm",
         margin: "0 auto",

--- a/components/documents/certification-request-document.tsx
+++ b/components/documents/certification-request-document.tsx
@@ -31,9 +31,9 @@ export function CertificationRequestDocument({
     <div
       style={{
         width: "100%",
-        fontFamily: "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif",
+        fontFamily: "Times New Roman, serif",
         fontSize: "11pt",
-        lineHeight: "1.5",
+        lineHeight: "1.3",
         letterSpacing: "0.3px",
         padding: "20px",
         margin: "0",


### PR DESCRIPTION
## Summary
- adjust PDF CSS to use Times New Roman body and add heading styles
- set contract and document components to Times New Roman 11pt with tighter line height

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d9a34ec4832a8babe8d15575317e